### PR TITLE
oci-hook: allow swapping for all burstable QoS pods

### DIFF
--- a/OCI-hook/hook.sh
+++ b/OCI-hook/hook.sh
@@ -5,9 +5,9 @@ echo "WASP SWAP hook"
 set -x
 
 CG_PATH=$(jq -er '.linux.cgroupsPath' < config.json)
-POD_NAME=$(jq -er '.annotations["io.kubernetes.pod.name"]' < config.json)
+POD_NAMESPACE=$(jq -er '.annotations["io.kubernetes.pod.namespace"]' < config.json)
 
-if [[ "$CG_PATH" =~ .*"burst".* && "$POD_NAME" =~ "virt-launcher".* ]];
+if [[ "$CG_PATH" =~ .*"burst".* && ! "$POD_NAMESPACE" =~ "openshift".* ]];
 then
   CONTAINERID=$(jq -er '.linux.cgroupsPath | split(":")[2]' < config.json)
   runc update $CONTAINERID --memory-swap -1


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Also use heuristic of filtering the openshift prefix ns as these containers considered system critical and we don't want then to swap