### PR TITLE
ci: temporary skip the bash linter for main branch

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,10 +2,10 @@ name: lint
 
 on:
   push:
-    branches: ['main']
-    tags: ['v*']
+    branches: ['!main']
+    tags: ['!v*']
   pull_request:
-    branches: ['main']
+    branches: ['!main']
 
 jobs:
   bash:


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>
